### PR TITLE
[AO] add support for auth-login-stub URLs

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/TcpProxies.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/TcpProxies.scala
@@ -37,6 +37,7 @@ class TcpProxies @Inject() (appConfig: FrontendConfig)(implicit system: ActorSys
   private val identityVerificationFrontendPort = appConfig.ivFEPort
   private val governmentGatewayRegistrationFrontendPort = appConfig.ggRegEPort
   private val personalDetailsValidationFrontendPort = appConfig.pvDetailsValidationFEPort
+  private val authLoginStubPort = appConfig.authLoginStubPort
   private val httpPort = appConfig.httpPort
 
   if (startProxies) {
@@ -65,6 +66,7 @@ class TcpProxies @Inject() (appConfig: FrontendConfig)(implicit system: ActorSys
     startProxy(identityVerificationFrontendPort, "identity-verification-frontend")
     startProxy(governmentGatewayRegistrationFrontendPort, "government-gateway-registration-frontend")
     startProxy(personalDetailsValidationFrontendPort, "personal-details-validation-frontend")
+    startProxy(authLoginStubPort, "auth-login-stub")
 
   } else {
     println("TCP proxies feature switched off")

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/config/FrontendConfig.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/config/FrontendConfig.scala
@@ -41,6 +41,8 @@ class FrontendConfig @Inject() (servicesConfig: ServicesConfig) {
 
   val pvDetailsValidationFEPort = getConfInt("personal-details-validation-frontend.port")
 
+  val authLoginStubPort = getConfInt("auth-login-stub.port")
+
   val httpPort = servicesConfig.getInt("http.port")
 
   val proxiesStart = servicesConfig.getBoolean("proxies.start")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -24,6 +24,9 @@ GET         /agents-external-stubs/gg/sign-out                                  
 GET         /stride/sign-in                                                        @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showSignInStridePage(successURL: RedirectUrl, origin: Option[String], failureURL: Option[String])
 GET         /agents-external-stubs/stride/sign-in                                  @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showSignInStridePageInternal(successURL: RedirectUrl, origin: Option[String], failureURL: Option[String])
 
+# auth-login-stub support
+GET         /auth-login-stub/gg-sign-in                                             @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showSignInPage(continue: Option[RedirectUrl], origin: Option[String], accountType: Option[String])
+
 # government gateway registration frontend stubs
 GET         /government-gateway-registration-frontend                              @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showGovernmentGatewaySignInPage(continue: Option[RedirectUrl] ?= None, origin: Option[String] ?= None, accountType: Option[String] ?= None)
 GET         /agents-external-stubs/government-gateway-registration-frontend        @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showGovernmentGatewaySignInPageInternal(continue: Option[RedirectUrl] ?= None, origin: Option[String] ?= None, accountType: Option[String] ?= None)
@@ -33,7 +36,7 @@ GET         /agents-external-stubs/government-gateway-registration-frontend     
 GET        /mdtp/uplift                                                             @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.showUpliftPageProxy(confidenceLevel: Int, completionURL: RedirectUrl, failureURL: RedirectUrl, origin: Option[String])
 POST       /mdtp/uplift                                                             @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.upliftProxy(journeyId: String, confidenceLevel: Int, completionURL: RedirectUrl, failureURL: RedirectUrl, origin: Option[String])
 GET        /agents-external-stubs/mdtp/uplift                                       @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.showUpliftPageInternal(confidenceLevel: Int, completionURL: RedirectUrl, failureURL: RedirectUrl, origin: Option[String])
-POST       /agents-external-stubs/mdtp/uplift                                       @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.upliftInternal(journeyId: String, confidenceLevel: Int, completionURL: RedirectUrl, failureURL: RedirectUrl, origin: Option[String])
+POST       /agents-external-stubs/mdtp/uplift                                           @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.upliftInternal(journeyId: String, confidenceLevel: Int, completionURL: RedirectUrl, failureURL: RedirectUrl, origin: Option[String])
 
 GET        /mdtp/journey/journeyId/:journeyId                                       @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.getIvResultProxy(journeyId: String)
 GET        /agents-external-stubs/mdtp/journey/journeyId/:journeyIdAndReason        @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.IdentityVerificationController.getIvResultInternal(journeyIdAndReason: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -132,6 +132,10 @@ microservice {
       host = localhost
       port = 9968
     }
+    auth-login-stub {
+      host = localhost
+      port = 9949
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds support for seamlessly handling `http://localhost:9949/auth-login-stub/gg-sign-in?continue=...` requests.