### PR TITLE
[AO] make self-authorization work again

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -202,3 +202,4 @@ features {
 }
 
 Prod.external-url.company-auth-frontend.host=/agents-external-stubs
+Prod.external-url.bas-gateway-frontend.host=/agents-external-stubs


### PR DESCRIPTION
Currently, any time you try to access AESF it redirects back to bas-gateway, which defies the purpose of this stub. That bug has been introduced by the HMRC-wide switch from company-auth-frontend to bas-gateway-frontend which wasn't followed by the configuration change in the AESF. This PR adds an expected override of the auth host.