### PR TITLE
APB-5837 Granular Permissions test user creation

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/connectors/AgentsExternalStubsConnector.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/connectors/AgentsExternalStubsConnector.scala
@@ -110,6 +110,18 @@ class AgentsExternalStubsConnector @Inject() (appConfig: FrontendConfig, http: H
       .recover(handleNotFound)
       .map(_ => ())
 
+  def massCreateAssistantsAndUsers(
+    request: GranPermsGenRequest
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[GranPermsGenResponse] =
+    http
+      .POST[GranPermsGenRequest, GranPermsGenResponse](
+        new URL(
+          s"$baseUrl/agents-external-stubs/test/gran-perms/generate-users"
+        ).toExternalForm,
+        request
+      )
+      .recover(handleNotFound)
+
   def getRecords(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Records] =
     http.GET[Records](new URL(s"$baseUrl/agents-external-stubs/records").toExternalForm).recover(handleNotFound)
 

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/models/GranPermsGenRequest.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/models/GranPermsGenRequest.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsexternalstubsfrontend.models
+
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import play.api.data.Form
+import play.api.data.Forms._
+import play.api.libs.json.Json
+
+/** Request for generating large number of users for the purpose of testing Granular Permissions.
+  */
+case class GranPermsGenRequest(
+  idPrefix: String,
+  numberOfAgents: Int,
+  numberOfClients: Int,
+  clientTypeDistribution: Option[Map[String, Double]] = None,
+  individualServiceDistribution: Option[Map[String, Double]] = None,
+  organisationServiceDistribution: Option[Map[String, Double]] = None
+)
+
+object GranPermsGenRequest {
+  implicit val format = Json.format[GranPermsGenRequest]
+}
+
+case class GranPermsGenResponse(
+  createdAgents: Seq[User],
+  createdClients: Seq[User]
+)
+
+object GranPermsGenResponse {
+  implicit val format = Json.format[GranPermsGenResponse]
+}
+
+object GranPermsGenRequestForm {
+  val form: Form[GranPermsGenRequest] = Form[GranPermsGenRequest](
+    mapping(
+      "idPrefix"        -> nonEmptyText,
+      "numberOfAgents"  -> number,
+      "numberOfClients" -> number
+    )(formApply)(formUnapply)
+  )
+
+  private def formApply(idPrefix: String, nAgents: Int, nClients: Int) =
+    GranPermsGenRequest(idPrefix = idPrefix, numberOfAgents = nAgents, numberOfClients = nClients)
+
+  private def formUnapply(genRequest: GranPermsGenRequest): Option[(String, Int, Int)] =
+    Some((genRequest.idPrefix, genRequest.numberOfAgents, genRequest.numberOfClients))
+}

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/gran_perms_user_gen.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/gran_perms_user_gen.scala.html
@@ -1,0 +1,75 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentsexternalstubsfrontend.models._
+@import uk.gov.hmrc.agentsexternalstubsfrontend.controllers.RestQueryController.RestQuery
+@import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.main_template
+@import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.navigationBar
+@import play.api.libs.ws.WSResponse
+@import play.mvc.Http.HeaderNames
+@import play.api.libs.json.Json
+@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Input
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.button.Button
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import views.html.helper.CSPNonce
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
+
+@this(
+        mainTemplate: main_template,
+        navigationBar: navigationBar,
+        form: FormWithCSRF,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        govukErrorSummary: GovukErrorSummary)
+
+@(reqForm: Form[GranPermsGenRequest])(implicit request: Request[_], msgs: Messages)
+
+@mainTemplate(title = "Generate test users for Granular Permissions", wide = true) {
+
+    <h1 class="govuk-heading-l">Generate test users for Granular Permissions</h1>
+
+    @form(action = Call("POST", "/agents-external-stubs/test/gran-perms/generate-users-form"), 'id -> "restQueryForm", 'novalidate -> "novalidate") {
+        @govukInput(Input(
+            label = Label(content = Text("ID prefix")),
+            hint = Some(Hint(content = Text("The IDs of the users created will be prefixed with this string."))),
+            classes = "govuk-input govuk-input--width-10"
+        ).withFormField(reqForm("idPrefix")))
+        @govukInput(Input(
+            label = Label(content = Text("Number of agents")),
+            hint = Some(Hint(content = Text("The number of agents to generate. They will each be delegated all of the clients' enrolments."))),
+            classes = "govuk-input govuk-input--width-10"
+        ).withFormField(reqForm("numberOfAgents")))
+        @govukInput(Input(
+            label = Label(content = Text("Number of clients")),
+            hint = Some(Hint(content = Text("The number of clients to generate. They will have a random mixture of enrolments."))),
+            classes = "govuk-input govuk-input--width-10"
+        ).withFormField(reqForm("numberOfClients")))
+
+        <div class="govuk-button-group">
+            @govukButton(Button(
+                content = Text("Submit"),
+                attributes = Map("id" -> "submit")
+            ))
+        </div>
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -63,6 +63,10 @@ GET         /agents-external-stubs/user/amend                                   
 GET         /agents-external-stubs/user/remove                                     @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.UserController.removeUser(continue: Option[RedirectUrl] ?= None, userId: Option[String] ?= None)
 GET         /agents-external-stubs/users                                           @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.UserController.showAllUsersPage
 
+#Granular permissions test URLs
+GET         /agents-external-stubs/test/gran-perms/generate-users-form             @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.UserController.showGranPermsCreateUsers
+POST        /agents-external-stubs/test/gran-perms/generate-users-form             @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.UserController.submitGranPermsCreateUsers
+
 GET         /agents-external-stubs/records                                         @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.RecordsController.showAllRecordsPage(showId: Option[String] ?= None)
 GET         /agents-external-stubs/records/edit                                    @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.RecordsController.showEditRecordPage(id: String)
 POST        /agents-external-stubs/records/update                                  @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.RecordsController.updateRecord(id: String)


### PR DESCRIPTION
(depends on [pull request 96](https://github.com/hmrc/agents-external-stubs/pull/96) in agents-external-stubs)