### PR TITLE
Increases request timeout when calling backend to mass-generate users

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/PlanetController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/PlanetController.scala
@@ -41,7 +41,7 @@ class PlanetController @Inject() (
       .retrieve(Retrievals.credentialsWithPlanetId) { credentials =>
         agentsExternalStubsConnector
           .destroyPlanet(credentials.planetId)
-          .map(_ => Redirect(routes.UserController.start()).withNewSession)
+          .map(_ => Redirect(routes.UserController.start).withNewSession)
       }
   }
 

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/RestQueryController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/RestQueryController.scala
@@ -67,7 +67,7 @@ class RestQueryController @Inject() (
                 Ok(
                   restQueryView(
                     RestQueryForm.fill(RestQuery("GET", "https://", None, None)),
-                    routes.RestQueryController.runQuery(),
+                    routes.RestQueryController.runQuery,
                     routes.UserController.showUserPage(),
                     routes.RestQueryController.showRestQueryPage(None),
                     None,
@@ -87,7 +87,7 @@ class RestQueryController @Inject() (
                         Ok(
                           restQueryView(
                             RestQueryForm.fill(rq),
-                            routes.RestQueryController.runQuery(),
+                            routes.RestQueryController.runQuery,
                             routes.UserController.showUserPage(),
                             routes.RestQueryController.showRestQueryPage(None),
                             Option(response),
@@ -100,7 +100,7 @@ class RestQueryController @Inject() (
                         Ok(
                           restQueryView(
                             RestQueryForm.fill(rq).withGlobalError(e.getMessage),
-                            routes.RestQueryController.runQuery(),
+                            routes.RestQueryController.runQuery,
                             routes.UserController.showUserPage(),
                             routes.RestQueryController.showRestQueryPage(None),
                             None,
@@ -129,7 +129,7 @@ class RestQueryController @Inject() (
                   Ok(
                     restQueryView(
                       formWithErrors,
-                      routes.RestQueryController.runQuery(),
+                      routes.RestQueryController.runQuery,
                       routes.UserController.showUserPage(),
                       routes.RestQueryController.showRestQueryPage(None),
                       None,

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/UserController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/UserController.scala
@@ -285,7 +285,7 @@ class UserController @Inject() (
           val id = userId.getOrElse(credentials.providerId)
           (if (id == credentials.providerId) Future.successful(())
            else agentsExternalStubsConnector.removeUser(id))
-            .map(_ => Redirect(routes.UserController.showAllUsersPage()))
+            .map(_ => Redirect(routes.UserController.showAllUsersPage))
             .recover { case NonFatal(e) =>
               Ok(errorTemplateView("error.title", s"Error while removing $id", e.getMessage))
             }

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/WithPageContext.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/WithPageContext.scala
@@ -45,9 +45,9 @@ trait WithPageContext {
 object Menus {
 
   val item1 = MenuItem("link_records_all", "records.link.all", routes.RecordsController.showAllRecordsPage())
-  val item2 = MenuItem("link_users_all", "users.link.all", routes.UserController.showAllUsersPage())
+  val item2 = MenuItem("link_users_all", "users.link.all", routes.UserController.showAllUsersPage)
   val item3 = MenuItem("link_users_current", "users.link.current", routes.UserController.showUserPage())
-  val item4 = MenuItem("link_help_enrolments", "services.link.short", routes.KnownFactsController.showEnrolmentsPage())
+  val item4 = MenuItem("link_help_enrolments", "services.link.short", routes.KnownFactsController.showEnrolmentsPage)
   val item7 =
     MenuItem("link_special_cases", "specialCase.link.short", routes.SpecialCasesController.showAllSpecialCasesPage())
   val item5 =

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ lazy val scoverageSettings = {
 
 lazy val compileDeps = Seq(
   ws,
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.20.0",
-  "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.5.0-play-28",
-  "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "0.34.0-play-28",
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "7.1.0",
+  "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.24.0-play-28",
+  "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "0.46.0-play-28",
   "uk.gov.hmrc"       %% "play-partials"              % "8.3.0-play-28",
   "uk.gov.hmrc"       %% "agent-kenshoo-monitoring"   % "4.8.0-play-28",
   "com.typesafe.play" %% "play-json-joda"             % "2.9.2"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,6 +25,7 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%level] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.google.inject" level="OFF"/>
+    <logger name="org.asynchttpclient.netty" level="OFF"/>
+    <logger name="io.netty.buffer" level="OFF"/>
+    <logger name="play.core.netty" level="OFF"/>
+
+    <root level="DEBUG">
+        <!-- We send DEBUG logs to an ERROR-filtering appender rather than setting log level to ERROR directly
+        so that all the logging statements are exercised during tests -->
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/AuthActionsISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/AuthActionsISpec.scala
@@ -1,12 +1,11 @@
 package uk.gov.hmrc.agentsexternalstubsfrontend.controllers
 
 import play.api.mvc.Result
-import play.api.test.FakeRequest
-import uk.gov.hmrc.agentsexternalstubsfrontend.support.BaseISpec
-import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, InsufficientEnrolments}
-import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 import play.api.mvc.Results._
 import play.api.test.Helpers._
+import uk.gov.hmrc.agentsexternalstubsfrontend.support.BaseISpec
+import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, InsufficientEnrolments}
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier}
 
 import scala.concurrent.Future
 
@@ -16,8 +15,7 @@ class AuthActionsISpec extends BaseISpec {
 
     override def authConnector: AuthConnector = app.injector.instanceOf[AuthConnector]
 
-    implicit val hc = HeaderCarrier()
-    implicit val request = FakeRequest().withSession(SessionKeys.authToken -> "Bearer XYZ")
+    implicit val hc: HeaderCarrier = HeaderCarrier(authorization = Some(Authorization("Bearer XYZ")))
     import scala.concurrent.ExecutionContext.Implicits.global
 
     def withAuthorisedAsAgent[A]: Result =

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/IdentityVerificationControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/IdentityVerificationControllerISpec.scala
@@ -32,6 +32,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
         val result =
           callEndpointWith(
             FakeRequest(GET, "/mdtp/uplift?confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=aif")
+              .withSession("authToken" -> "Bearer XYZ")
           )
         status(result) shouldBe 200
         checkHtmlResultWithBodyText(result, htmlEscapedMessage("uplift.header"))
@@ -62,7 +63,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
           FakeRequest(
             POST,
             "/mdtp/uplift?journeyId=1234&confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=ai"
-          )
+          ).withSession("authToken" -> "Bearer XYZ")
             .withFormUrlEncodedBody("nino" -> "AB626225C", "option" -> "Success~1234")
         )
 
@@ -79,7 +80,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
           FakeRequest(
             POST,
             "/mdtp/uplift?journeyId=1234&confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=ai"
-          )
+          ).withSession("authToken" -> "Bearer XYZ")
             .withFormUrlEncodedBody("nino" -> "AB626225C", "option" -> "PreconditionFailed~1234")
         )
 
@@ -97,6 +98,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
 
         val result = callEndpointWith(
           FakeRequest(GET, "/agents-external-stubs/mdtp/uplift?confidenceLevel=250&completionURL=/good&failureURL=/bad")
+            .withSession("authToken" -> "Bearer XYZ")
         )
         status(result) shouldBe 200
         checkHtmlResultWithBodyText(result, htmlEscapedMessage("uplift.header"))
@@ -133,7 +135,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
           FakeRequest(
             POST,
             "/agents-external-stubs/mdtp/uplift?journeyId=1234&confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=ai"
-          )
+          ).withSession("authToken" -> "Bearer XYZ")
             .withFormUrlEncodedBody("nino" -> "AB626225C", "option" -> "Success~1234")
         )
 
@@ -151,7 +153,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
           FakeRequest(
             POST,
             "/agents-external-stubs/mdtp/uplift?journeyId=1234&confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=ai"
-          )
+          ).withSession("authToken" -> "Bearer XYZ")
             .withFormUrlEncodedBody("nino" -> "AB626225C", "option" -> "PreconditionFailed~1234")
         )
 
@@ -171,7 +173,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
           FakeRequest(
             POST,
             "/agents-external-stubs/mdtp/uplift?journeyId=1234&confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=ai"
-          )
+          ).withSession("authToken" -> "Bearer XYZ")
             .withFormUrlEncodedBody("nino" -> "AB626225C", "option" -> "PreconditionFailed~1234")
         )
 
@@ -200,7 +202,7 @@ class IdentityVerificationControllerISpec extends BaseISpec with AgentsExternalS
           FakeRequest(
             POST,
             "/agents-external-stubs/mdtp/uplift?journeyId=1234&confidenceLevel=250&completionURL=/good&failureURL=/bad&origin=ai"
-          )
+          ).withSession("authToken" -> "Bearer XYZ")
             .withFormUrlEncodedBody("nino" -> "AB626225C", "option" -> "PreconditionFailed~1234")
         )
 

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/KnownFactsControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/KnownFactsControllerISpec.scala
@@ -28,7 +28,7 @@ class KnownFactsControllerISpec extends BaseISpec with AgentsExternalStubsStubs 
             )
         )
         givenUser(User("Test123"))
-        val request = FakeRequest(GET, "/agents-external-stubs/services")
+        val request = FakeRequest(GET, "/agents-external-stubs/services").withSession("authToken" -> "Bearer XYZ")
         val result = callEndpointWith(request)
         status(result) shouldBe 200
       }

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/PlanetControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/PlanetControllerISpec.scala
@@ -25,7 +25,7 @@ class PlanetControllerISpec extends BaseISpec with AgentsExternalStubsStubs with
             )
         )
 
-        val request = FakeRequest(GET, "/agents-external-stubs/planet/destroy")
+        val request = FakeRequest(GET, "/agents-external-stubs/planet/destroy").withSession("authToken" -> "Bearer XYZ")
 
         val result = callEndpointWith(request)
         status(result) shouldBe 303

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/RestQueryControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/RestQueryControllerISpec.scala
@@ -17,7 +17,8 @@ class RestQueryControllerISpec extends BaseISpec with AgentsExternalStubsStubs w
       "render rest-query page" in {
         givenAuthorised()
 
-        val request = FakeRequest(GET, "/agents-external-stubs/rest-query")
+        val request =
+          FakeRequest(GET, "/agents-external-stubs/rest-query").withSession("authToken" -> "Bearer XYZ")
 
         val result = callEndpointWith(request)
         status(result) shouldBe 200

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/SignInControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/SignInControllerISpec.scala
@@ -89,7 +89,7 @@ class SignInControllerISpec extends BaseISpec with AgentsExternalStubsStubs {
       "redirect to continue URL if provided" in {
         val authToken = givenUserCanSignIn("foo", "juniper", newUser = false)
         val result = controller.signIn(Some(RedirectUrl("/there")), None, None, AuthProvider.GovernmentGateway)(
-          FakeRequest()
+          FakeRequest("POST", "/gg/sign-in")
             .withFormUrlEncodedBody("userId" -> "foo", "planetId" -> "juniper")
         )
         status(result) shouldBe 303
@@ -101,7 +101,7 @@ class SignInControllerISpec extends BaseISpec with AgentsExternalStubsStubs {
       "redirect to edit user with if new one created" in {
         val authToken = givenUserCanSignIn("foo", "saturn", newUser = true)
         val result = controller.signIn(Some(RedirectUrl("/there")), None, None, AuthProvider.GovernmentGateway)(
-          FakeRequest()
+          FakeRequest("POST", "/gg/sign-in")
             .withFormUrlEncodedBody("userId" -> "foo", "planetId" -> "saturn")
         )
         status(result) shouldBe 303
@@ -161,7 +161,7 @@ class SignInControllerISpec extends BaseISpec with AgentsExternalStubsStubs {
       "redirect to continue URL if provided" in {
         val authToken = givenUserCanSignIn("foo", "juniper", newUser = false)
         val result = controller.signInInternal(Some(RedirectUrl("/there")), None, None, AuthProvider.GovernmentGateway)(
-          FakeRequest()
+          FakeRequest("POST", "/agents-external-stubs/gg/sign-in")
             .withFormUrlEncodedBody("userId" -> "foo", "planetId" -> "juniper")
         )
         status(result) shouldBe 303
@@ -173,7 +173,7 @@ class SignInControllerISpec extends BaseISpec with AgentsExternalStubsStubs {
       "redirect to edit user with if new one created" in {
         val authToken = givenUserCanSignIn("foo", "saturn", newUser = true)
         val result = controller.signInInternal(Some(RedirectUrl("/there")), None, None, AuthProvider.GovernmentGateway)(
-          FakeRequest()
+          FakeRequest("POST", "/agents-external-stubs/gg/sign-in")
             .withFormUrlEncodedBody("userId" -> "foo", "planetId" -> "saturn")
         )
         status(result) shouldBe 303

--- a/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/UserControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/UserControllerISpec.scala
@@ -19,7 +19,7 @@ class UserControllerISpec extends BaseISpec with AgentsExternalStubsStubs with A
         givenAuthorised("Test123")
         givenUser(User("Test123"))
 
-        val request = FakeRequest(GET, "/agents-external-stubs/user")
+        val request = FakeRequest(GET, "/agents-external-stubs/user").withSession("authToken" -> "Bearer XYZ")
 
         val result = callEndpointWith(request)
         status(result) shouldBe 200

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.1")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.8.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
- The main change is in _AgentsExternalStubsConnector.massCreateAssistantsAndUsers()_ that now uses _HttpClientV2_ to set a request timeout value.
-  Other changes in the PR are due to dependency/plugin upgrades