### PR TITLE
Cs/new asa landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Agents External Stubs Frontend
 
-[ ![Download](https://api.bintray.com/packages/hmrc/releases/agents-external-stubs-frontend/images/download.svg) ](https://bintray.com/hmrc/releases/agents-external-stubs-frontend/_latestVersion)
-
 This microservice is part of Agent Services local testing framework, 
 providing necessary UI stubs complementing API stubs in [agents-external-stubs](https://github.com/hmrc/agents-external-stubs).
 
@@ -16,51 +14,16 @@ To handle requests aimed at stubbed frontend microservices we provide necessary 
 You can switch this behaviour off by setting `proxies.start` config property to `false`.
 
 ## Data Model
-Every stubbed user and other data live is some test sandbox (planet). 
-You have to declare existing or a new planet whenever you sign-in. Each authenticated session have planetId information. 
-Stubbed and custom UIs will consider only users and data assigned to the current planet.
+Every stubbed user and other data live in some test sandbox (planet). 
+You have to declare existing or a new planet whenever you sign-in. Each authenticated session has planetId information. 
+Stubbed and custom UIs will consider only users and data assigned to the current planet. Other apps may contain data from multiple planets and can clash, so avoid the same names for your users with concurrent planets or tidy up data on these regularly.
 
 User authentication expires after 15 minutes and so does the bearer token.
 All users and other data on each planet are removed after 12h unless marked as permanent.
 
 ## Stubbed UIs
 
-### [BAS Gateway Frontend](https://github.com/hmrc/bas-gateway-frontend/blob/master/README.md)
-#### GET         /bas-gateway/sign-in  
-Initiates the login journey, eventually creating an authenticated MDTP session                                      
-#### GET         /bas-gateway/sso-sign-in
-Initiates the sso login flow for BAS through MDTP
-#### GET         /bas-gateway/sign-out-without-state
-#### GET         /bas-gateway/sign-out-with-state
-#### GET         /bas-gateway/register 
-Sends the user to register a new SCP account
-
-### [Company Auth Frontend](https://github.com/hmrc/company-auth-frontend/blob/master/README.md)
-#### GET /gg/sign-in?continue=:continueUrl&accountType=:accountType&origin=:origin
-Shows login page.
-
-#### POST /gg/sign-in?continue=:continueUrl&accountType=:accountType&origin=:origin
-Submits user's credentials, creates session and redirects to the provided continue URL
-
-### [Identity Verification Frontend](https://github.com/hmrc/identity-verification-frontend/blob/master/README.md) 
-#### GET /mdtp/uplift?origin=:origin&confidenceLevel=:confidenceLevel&completionURL=:completionURL&failureURL=:failureURL
-Shows an identity verification page for the [IV "uplift" journey](https://github.com/hmrc/identity-verification-frontend/blob/master/README.md#get-mdtpuplift), offering the choice of either a successful or unsuccessful IV journey outcome.
-
-#### POST /mdtp/uplift?origin=:origin&confidenceLevel=:confidenceLevel&completionURL=:completionURL&failureURL=:failureURL
-Submits the desired outcome of the identity verification "uplift" journey.
-If a successful outcome was chosen, this will increase the confidence level of the current user to the provided confidence level and redirect to the provided completion URL.
-If an unsuccessful outcome was chosen, this will just redirect to the provided failure URL.
-
-## Custom UI
-
-#### GET /agents-external-stubs/user
-Shows current user auth settings
-
-#### GET /agents-external-stubs/user/edit
-Displays form to edit current user auth settings
-
-#### POST /agents-external-stubs/user/edit
-Submits amended user auth settings
+See [stubbed UIs](docs/stubbed-ui.md)
 
 ## Running the tests
 
@@ -72,15 +35,15 @@ Submits amended user auth settings
 
 ## Running the app locally
 
-    sm2 --start AWESOME_STUBS -f
-    sm2 --start AWESOME_STUBS_FRONTEND -f
+    sm2 --start AWESOME_STUBS
+    sm2 --start AWESOME_STUBS_FRONTEND
     
 or with AGENTS_EXTERNAL_STUBS also running
     sbt run
 
 It should then be listening on ports 9099 and 9025
 
-    browse http://localhost:9099/
+    browse http://localhost:9099/agents-external-stubs/quick-start-hub
 
 ### License
 

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/SignInController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/SignInController.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.{Json, Writes}
 import play.api.mvc._
 import uk.gov.hmrc.agentsexternalstubsfrontend.connectors.{AgentsExternalStubsConnector, AuthenticatedSession}
 import uk.gov.hmrc.agentsexternalstubsfrontend.models.AuthProvider
-import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.sign_in
+import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.{quick_start_agents_hub, sign_in}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.SessionKeys
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,6 +41,7 @@ class SignInController @Inject() (
   override val messagesApi: MessagesApi,
   val agentsExternalStubsConnector: AgentsExternalStubsConnector,
   signInView: sign_in,
+  quickStartView: quick_start_agents_hub,
   val authConnector: AuthConnector,
   ecp: Provider[ExecutionContext],
   sessionCookieBaker: SessionCookieBaker
@@ -50,6 +51,10 @@ class SignInController @Inject() (
   implicit val ec: ExecutionContext = ecp.get
 
   import SignInController._
+
+  def showQuickStart(): Action[AnyContent] = Action { implicit request =>
+    Ok(quickStartView())
+  }
 
   def showSignInPage(
     continue: Option[RedirectUrl],
@@ -83,21 +88,21 @@ class SignInController @Inject() (
     continue: Option[RedirectUrl],
     origin: Option[String],
     accountType: Option[String]
-  ) = showSignInPage(continue, origin, accountType)
+  ): Action[AnyContent] = showSignInPage(continue, origin, accountType)
 
   def signInSsoSCP(
     continue_url: Option[RedirectUrl],
     origin: Option[String],
     accountType: Option[String]
   ): Action[AnyContent] =
-    signInSsoImpl(continue_url, origin, accountType, false)
+    signInSsoImpl(continue_url, origin, accountType, internal = false)
 
   def signInSsoInternalSCP(
     continue_url: Option[RedirectUrl],
     origin: Option[String],
     accountType: Option[String]
   ): Action[AnyContent] =
-    signInSsoImpl(continue_url, origin, accountType, true)
+    signInSsoImpl(continue_url, origin, accountType, internal = true)
 
   private def signInSsoImpl(
     continue_url: Option[RedirectUrl],
@@ -265,7 +270,7 @@ class SignInController @Inject() (
     continue: Option[RedirectUrl],
     origin: Option[String],
     accountType: Option[String]
-  ) = showSignInPageInternal(continue, origin, accountType)
+  ): Action[AnyContent] = showSignInPageInternal(continue, origin, accountType)
 
   def showSignInStridePageInternal(
     successURL: RedirectUrl,

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/WithPageContext.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/controllers/WithPageContext.scala
@@ -53,7 +53,7 @@ object Menus {
     MenuItem("link_special_cases", "specialCase.link.short", routes.SpecialCasesController.showAllSpecialCasesPage())
   val item5 =
     MenuItem("link_rest_query", "rest.query.link.short", routes.RestQueryController.showRestQueryPage())
-  val item6 = MenuItem("link_sign_out", "common.sign-out", routes.SignInController.signOutInternal())
+  val item6 = MenuItem("link_quick_start", "ASA links", routes.SignInController.showQuickStart())
 
   val menu1 = Seq(item1, item2, item2b, item3, item7, item6)
   val menu2 = Seq(item1, item2, item2b, item3, item4, item7, item6)

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/main_template.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.agentsexternalstubsfrontend.controllers.routes
 @import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.components.head
 @import uk.gov.hmrc.govukfrontend.views.html.components.{TwoThirdsOneThirdMainContent}
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.{HmrcStandardPage, HmrcTrackingConsentSnippet}
@@ -47,7 +48,7 @@
     isWelshTranslationAvailable = false,
     serviceURLs = ServiceURLs(
         serviceUrl = None,
-        signOutUrl = None
+        signOutUrl = Some(routes.SignInController.signOutInternal().url)
     ),
     banners = Banners(displayHmrcBanner = true),
     templateOverrides = TemplateOverrides(

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/main_template.scala.html
@@ -33,6 +33,7 @@
 @(
     title: String,
     backLinkHref: Option[String] = None,
+    showSignOut: Boolean = true,
     wide: Boolean = false,
     sidebar: Option[Html] = None // overrides the 'wide' option if present
 )(mainContent: Html)(implicit request : Request[_], msgs: Messages)
@@ -48,7 +49,7 @@
     isWelshTranslationAvailable = false,
     serviceURLs = ServiceURLs(
         serviceUrl = None,
-        signOutUrl = Some(routes.SignInController.signOutInternal().url)
+        signOutUrl = if(showSignOut) Some(routes.SignInController.signOutInternal().url) else None
     ),
     banners = Banners(displayHmrcBanner = true),
     templateOverrides = TemplateOverrides(

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
@@ -25,41 +25,46 @@ a: a
 
 @(isDev: Boolean = true)(implicit request: Request[_], msgs: Messages)
 
-@baseUrl = @{ if(isDev) request.host.concat(request.uri) else request.uri }
+@baseUrl = @{ if(isDev) request.host else request.uri }
 
 @* don't need to be signed in to view this page *@
-@mainTemplate(title = "Quick start hub", wide = true, showSignOut = false) {
+@mainTemplate(title = "Quick start hub - Agents team", wide = true, showSignOut = false) {
 
 <div class="govuk-grid-row">
-<h1 class="govuk-heading-l">Quick start hub - localhost only</h1>
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Quick start hub - localhost only</h1>
 
-<p class="govuk-body">Intended as a shortcut to the start of ASA journeys, must sign in with appropriate user type.</p>
-<p class="govuk-body">
-    @a(
-        key = "See all existing users (opens in a new tab)",
-        href =  routes.UserController.showAllUsersPage.url,
-        openInNewWindow = true
-    )
-</p>
+        <p class="govuk-body">Intended as a shortcut to the start of ASA journeys, must sign in with appropriate user type.</p>
+        <p class="govuk-body">
+            @a(
+                key = "See all existing users (opens in a new tab)",
+                href =  routes.UserController.showAllUsersPage.url,
+                openInNewWindow = true
+            )
+        </p>
+    </div>
 </div>
 
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">As agent</h2>
+    </div>
+    <div class="govuk-grid-column-one-third">
     <p class="govuk-body govuk-body govuk-!-margin-bottom-0">primary enrolment is <strong>None</strong></p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      @a(key = "Agent subscription start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9437/agent-subscription/task-list")
-    </div>
-    <div class="govuk-grid-column-one-third">
-     @a(key = "Agent overseas sub start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9414/agent-services/apply-from-outside-uk&origin=agent-overseas-frontend")
+    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+        <li>
+            @a(key = "Agent subscription start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9437/agent-subscription/task-list")
+        </li>
+        <li>
+            @a(key = "Agent overseas sub start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9414/agent-services/apply-from-outside-uk&origin=agent-overseas-frontend")
+        </li>
+    </ul>
     </div>
 
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-half">
         <p class="govuk-body govuk-body govuk-!-margin-bottom-0">HMRC-AS-AGENT enrolment </p>
         @a(key = "Agent services account home", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9401/agent-services-account/home&origin=agent-services-account-frontend")
-
     </div>
     @* keep it small to start? ASA home lets you navigate to mapping/invitations
     @a(key = "Mapping", href = routes.UserController.showAllUsersPage.url)
@@ -83,26 +88,26 @@ a: a
     <h2 class="govuk-heading-m">As hmrc helpdesk staff (affinity type None with STRIDE)</h2>
     </div>
     <div class="govuk-grid-column-one-third">
-     <p class="govuk-body">stride role 'maintain_agent_relationships'</p>
+     <p class="govuk-body govuk-!-margin-bottom-1">stride role 'maintain_agent_relationships'</p>
      @a(key = "Digitally excluded authorisations", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fmanage-agent-authorisation%2Fstart&origin=agent-helpdesk-frontend")
     </div>
     <div class="govuk-grid-column-one-third">
-     <p class="govuk-body">stride role 'maintain_agent_overseas'</p>
+     <p class="govuk-body govuk-!-margin-bottom-1">stride role 'maintain_agent_overseas'</p>
      @a(key = "Review overseas applications", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-services%2Fcheck-application%2Fsearch-applications&origin=agent-helpdesk-frontend")
     </div>
     <div class="govuk-grid-column-one-third">
-     <p class="govuk-body">stride role 'maintain_agent_manually_assure'</p>
+     <p class="govuk-body govuk-!-margin-bottom-1">stride role 'maintain_agent_manually_assure'</p>
      @a(key = "Agent manually assured list - AMLS", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-assurance%2Fagent-lists&origin=agent-helpdesk-frontend")
     </div>
-    <div class="govuk-grid-column-full">
-     <p class="govuk-body">stride roles 'maintain_agent_manually_assure, maintain_agent_relationships'</p>
+    <div class="govuk-grid-column-full govuk-!-margin-top-5">
+     <p class="govuk-body govuk-!-margin-bottom-1">stride roles 'maintain_agent_manually_assure, maintain_agent_relationships'</p>
      @a(key = "Alt itsa screen", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fcheck-itsa-partial-agent-authorisation&origin=agent-helpdesk-frontend")
     </div>
 </div>
 
 <div class="govuk-grid-row">
     <br>
-    <a href="@baseUrl"> test link </a>
+    <a href="@baseUrl"> test link (host environment) - need to account for port if using local host... </a>
 </div>
 
 }

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
@@ -1,0 +1,62 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentsexternalstubsfrontend.controllers.routes
+@import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.components._
+@import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.{main_template, navigationBar}
+
+@this(
+mainTemplate: main_template,
+a: a, navigationBar: navigationBar
+)
+
+@()(implicit request: Request[_], msgs: Messages)
+
+@mainTemplate(title = "Quick start hub", wide = true) {
+
+<h1 class="govuk-heading-l">Quick start hub - localhost only</h1>
+
+<h2 class="govuk-heading-m">As agent</h2>
+<p> without HMRC-AS-AGENT enrolment </p>
+@a(key = "Agent subscription start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9437/agent-subscription/task-list")
+
+@a(key = "Agent overseas sub start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9414/agent-services/apply-from-outside-uk&origin=agent-overseas-frontend")
+
+<p> need HMRC-AS-AGENT enrolment </p>
+@a(key = "Agent services account home", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9401/agent-services-account/home&origin=agent-services-account-frontend")
+
+@* keep it small to start? ASA home lets you navigate to mapping/invitations
+@a(key = "Mapping", href = routes.UserController.showAllUsersPage.url)
+
+@a(key = "Invitations", href = routes.UserController.showAllUsersPage.url)
+*@
+<h2 class="govuk-heading-m">As client (individual/org)</h2>
+
+@a(key = "Manage your tax agents (agent-client-management-frontend)", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9568/manage-your-tax-agents&origin=agent-client-management-frontend")
+
+
+<h2 class="govuk-heading-m">As hmrc helpdesk staff (STRIDE)</h2>
+
+@a(key = "Digitally excluded authorisations", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fmanage-agent-authorisation%2Fstart&origin=agent-helpdesk-frontend")
+
+@a(key = "Review overseas applications", href = "http://localhost:9451/agent-services/check-application/search-applications")
+
+@a(key = "Agent manually assured list - AMLS", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-assurance%2Fagent-lists&origin=agent-helpdesk-frontend")
+
+@a(key = "Alt itsa screen", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fcheck-itsa-partial-agent-authorisation&origin=agent-helpdesk-frontend")
+
+
+}

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
@@ -23,7 +23,7 @@ mainTemplate: main_template,
 a: a
 )
 
-@(isDev = true)(implicit request: Request[_], msgs: Messages)
+@(isDev: Boolean = true)(implicit request: Request[_], msgs: Messages)
 
 @baseUrl = { if(isDev) request.host.concat(request.uri) else request.uri }
 

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
@@ -16,47 +16,82 @@
 
 @import uk.gov.hmrc.agentsexternalstubsfrontend.controllers.routes
 @import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.components._
-@import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.{main_template, navigationBar}
+@import uk.gov.hmrc.agentsexternalstubsfrontend.views.html.main_template
 
 @this(
 mainTemplate: main_template,
-a: a, navigationBar: navigationBar
+a: a
 )
 
-@()(implicit request: Request[_], msgs: Messages)
+@(isDev = true)(implicit request: Request[_], msgs: Messages)
 
-@mainTemplate(title = "Quick start hub", wide = true) {
+@baseUrl = { if(isDev) request.host.concat(request.uri) else request.uri }
+
+@* don't need to be signed in to view this page *@
+@mainTemplate(title = "Quick start hub", wide = true, showSignOut = false) {
 
 <h1 class="govuk-heading-l">Quick start hub - localhost only</h1>
 
-<h2 class="govuk-heading-m">As agent</h2>
-<p> without HMRC-AS-AGENT enrolment </p>
-@a(key = "Agent subscription start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9437/agent-subscription/task-list")
-
-@a(key = "Agent overseas sub start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9414/agent-services/apply-from-outside-uk&origin=agent-overseas-frontend")
-
-<p> need HMRC-AS-AGENT enrolment </p>
-@a(key = "Agent services account home", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9401/agent-services-account/home&origin=agent-services-account-frontend")
-
-@* keep it small to start? ASA home lets you navigate to mapping/invitations
-@a(key = "Mapping", href = routes.UserController.showAllUsersPage.url)
-
-@a(key = "Invitations", href = routes.UserController.showAllUsersPage.url)
-*@
-<h2 class="govuk-heading-m">As client (individual/org)</h2>
-
-@a(key = "Manage your tax agents (agent-client-management-frontend)", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9568/manage-your-tax-agents&origin=agent-client-management-frontend")
+<p class="govuk-body">Intended as a shortcut to the start of ASA journeys, must sign in with appropriate user type.</p>
+<p class="govuk-body">
+    @a(key = "See all existing users (opens in a new tab)", href =  routes.UserController.showAllUsersPage.url)
+</p>
 
 
-<h2 class="govuk-heading-m">As hmrc helpdesk staff (STRIDE)</h2>
+<div class="govuk-grid-row">
+    <h2 class="govuk-heading-m">As agent</h2>
+    <p class="govuk-body"> must NOT have HMRC-AS-AGENT enrolment</p>
+    <div class="govuk-grid-column-one-third">
+      @a(key = "Agent subscription start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9437/agent-subscription/task-list")
+    </div>
+    <div class="govuk-grid-column-one-third">
+     @a(key = "Agent overseas sub start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9414/agent-services/apply-from-outside-uk&origin=agent-overseas-frontend")
+    </div>
+</div>
 
-@a(key = "Digitally excluded authorisations", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fmanage-agent-authorisation%2Fstart&origin=agent-helpdesk-frontend")
+<div class="govuk-grid-row">
+ <p class="govuk-body"> with HMRC-AS-AGENT enrolment </p>
+ @a(key = "Agent services account home", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9401/agent-services-account/home&origin=agent-services-account-frontend")
+ @* keep it small to start? ASA home lets you navigate to mapping/invitations
+ @a(key = "Mapping", href = routes.UserController.showAllUsersPage.url)
 
-@a(key = "Review overseas applications", href = "http://localhost:9451/agent-services/check-application/search-applications")
+ @a(key = "Invitations", href = routes.UserController.showAllUsersPage.url)
+ *@
+</div>
 
-@a(key = "Agent manually assured list - AMLS", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-assurance%2Fagent-lists&origin=agent-helpdesk-frontend")
 
-@a(key = "Alt itsa screen", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fcheck-itsa-partial-agent-authorisation&origin=agent-helpdesk-frontend")
+<div class="govuk-grid-row">
+    <h2 class="govuk-heading-m">As client (individual/org)</h2>
+    <p class="govuk-body">If not using the agent invitation link... </p>
+ @a(key = "Manage your tax agents (agent-client-management-frontend)", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9568/manage-your-tax-agents&origin=agent-client-management-frontend")
+</div>
+
+
+<div class="govuk-grid-row">
+    <h2 class="govuk-heading-m">As hmrc helpdesk staff (affinity type None with STRIDE)</h2>
+    <div class="govuk-grid-column-one-quarter">
+     <p class="govuk-body"> with 'maintain_agent_relationships' stride role</p>
+     @a(key = "Digitally excluded authorisations", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fmanage-agent-authorisation%2Fstart&origin=agent-helpdesk-frontend")
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+     <p class="govuk-body"> with 'maintain_agent_overseas' stride role</p>
+     @a(key = "Review overseas applications", href = "http://localhost:9451/agent-services/check-application/search-applications")
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+     <p class="govuk-body"> with 'maintain_agent_manually_assure' stride role</p>
+     @a(key = "Agent manually assured list - AMLS", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-assurance%2Fagent-lists&origin=agent-helpdesk-frontend")
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+     <p class="govuk-body"> with 'maintain_agent_manually_assure, maintain_agent_relationships' stride roles</p>
+     @a(key = "Alt itsa screen", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fcheck-itsa-partial-agent-authorisation&origin=agent-helpdesk-frontend")
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <br>
+    <a href="@baseUrl"> test link </a>
+</div>
+
 
 
 }

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/quick_start_agents_hub.scala.html
@@ -25,64 +25,77 @@ a: a
 
 @(isDev: Boolean = true)(implicit request: Request[_], msgs: Messages)
 
-@baseUrl = { if(isDev) request.host.concat(request.uri) else request.uri }
+@baseUrl = @{ if(isDev) request.host.concat(request.uri) else request.uri }
 
 @* don't need to be signed in to view this page *@
 @mainTemplate(title = "Quick start hub", wide = true, showSignOut = false) {
 
+<div class="govuk-grid-row">
 <h1 class="govuk-heading-l">Quick start hub - localhost only</h1>
 
 <p class="govuk-body">Intended as a shortcut to the start of ASA journeys, must sign in with appropriate user type.</p>
 <p class="govuk-body">
-    @a(key = "See all existing users (opens in a new tab)", href =  routes.UserController.showAllUsersPage.url)
+    @a(
+        key = "See all existing users (opens in a new tab)",
+        href =  routes.UserController.showAllUsersPage.url,
+        openInNewWindow = true
+    )
 </p>
+</div>
 
 
 <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">As agent</h2>
-    <p class="govuk-body"> must NOT have HMRC-AS-AGENT enrolment</p>
+    <p class="govuk-body govuk-body govuk-!-margin-bottom-0">primary enrolment is <strong>None</strong></p>
+    </div>
     <div class="govuk-grid-column-one-third">
       @a(key = "Agent subscription start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9437/agent-subscription/task-list")
     </div>
     <div class="govuk-grid-column-one-third">
      @a(key = "Agent overseas sub start", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9414/agent-services/apply-from-outside-uk&origin=agent-overseas-frontend")
     </div>
+
+    <div class="govuk-grid-column-one-third">
+        <p class="govuk-body govuk-body govuk-!-margin-bottom-0">HMRC-AS-AGENT enrolment </p>
+        @a(key = "Agent services account home", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9401/agent-services-account/home&origin=agent-services-account-frontend")
+
+    </div>
+    @* keep it small to start? ASA home lets you navigate to mapping/invitations
+    @a(key = "Mapping", href = routes.UserController.showAllUsersPage.url)
+
+    @a(key = "Invitations", href = routes.UserController.showAllUsersPage.url)
+    *@
 </div>
 
 <div class="govuk-grid-row">
- <p class="govuk-body"> with HMRC-AS-AGENT enrolment </p>
- @a(key = "Agent services account home", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9401/agent-services-account/home&origin=agent-services-account-frontend")
- @* keep it small to start? ASA home lets you navigate to mapping/invitations
- @a(key = "Mapping", href = routes.UserController.showAllUsersPage.url)
-
- @a(key = "Invitations", href = routes.UserController.showAllUsersPage.url)
- *@
-</div>
-
-
-<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <br>
     <h2 class="govuk-heading-m">As client (individual/org)</h2>
-    <p class="govuk-body">If not using the agent invitation link... </p>
- @a(key = "Manage your tax agents (agent-client-management-frontend)", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9568/manage-your-tax-agents&origin=agent-client-management-frontend")
+    <p class="govuk-body govuk-!-margin-bottom-0">If not using the agent invitation link... </p>
+    @a(key = "Manage your tax agents (agent-client-management-frontend)", href = "http://localhost:9553/bas-gateway/sign-in?continue_url=http://localhost:9568/manage-your-tax-agents&origin=agent-client-management-frontend")
+    </div>
 </div>
 
-
 <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <br>
     <h2 class="govuk-heading-m">As hmrc helpdesk staff (affinity type None with STRIDE)</h2>
-    <div class="govuk-grid-column-one-quarter">
-     <p class="govuk-body"> with 'maintain_agent_relationships' stride role</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+     <p class="govuk-body">stride role 'maintain_agent_relationships'</p>
      @a(key = "Digitally excluded authorisations", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fmanage-agent-authorisation%2Fstart&origin=agent-helpdesk-frontend")
     </div>
-    <div class="govuk-grid-column-one-quarter">
-     <p class="govuk-body"> with 'maintain_agent_overseas' stride role</p>
-     @a(key = "Review overseas applications", href = "http://localhost:9451/agent-services/check-application/search-applications")
+    <div class="govuk-grid-column-one-third">
+     <p class="govuk-body">stride role 'maintain_agent_overseas'</p>
+     @a(key = "Review overseas applications", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-services%2Fcheck-application%2Fsearch-applications&origin=agent-helpdesk-frontend")
     </div>
-    <div class="govuk-grid-column-one-quarter">
-     <p class="govuk-body"> with 'maintain_agent_manually_assure' stride role</p>
+    <div class="govuk-grid-column-one-third">
+     <p class="govuk-body">stride role 'maintain_agent_manually_assure'</p>
      @a(key = "Agent manually assured list - AMLS", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fagent-assurance%2Fagent-lists&origin=agent-helpdesk-frontend")
     </div>
-    <div class="govuk-grid-column-one-quarter">
-     <p class="govuk-body"> with 'maintain_agent_manually_assure, maintain_agent_relationships' stride roles</p>
+    <div class="govuk-grid-column-full">
+     <p class="govuk-body">stride roles 'maintain_agent_manually_assure, maintain_agent_relationships'</p>
      @a(key = "Alt itsa screen", href = "http://localhost:9041/stride/sign-in?successURL=http%3A%2F%2Flocalhost%3A9451%2Fcheck-itsa-partial-agent-authorisation&origin=agent-helpdesk-frontend")
     </div>
 </div>
@@ -91,7 +104,5 @@ a: a
     <br>
     <a href="@baseUrl"> test link </a>
 </div>
-
-
 
 }

--- a/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/sign_in.scala.html
+++ b/app/uk/gov/hmrc/agentsexternalstubsfrontend/views/sign_in.scala.html
@@ -46,7 +46,7 @@
 
 @(loginForm:Form[uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.SignInRequest], postUrl: Call)(implicit request: Request[_], msgs: Messages)
 
-@mainTemplate(title = msgs("login.title")) {
+@mainTemplate(title = msgs("login.title"), showSignOut = false) {
 
     @form(action = postUrl, 'id -> "loginForm", 'novalidate -> "novalidate") {
         @govukFieldset(Fieldset(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,6 +2,8 @@
 ->          /agents-external-stubs/hmrc-frontend                                   hmrcfrontend.Routes
 GET         /agents-external-stubs/assets/*file                                    controllers.Assets.versioned(path = "/public", file)
 
+GET         /agents-external-stubs/quick-start-hub                                 @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showQuickStart()
+
 # bas-gateway-frontend stubs
 GET         /bas-gateway/sign-in                                                   @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.showSignInPageSCP(continue_url: Option[RedirectUrl], origin: Option[String])
 GET         /bas-gateway/sso-sign-in                                               @uk.gov.hmrc.agentsexternalstubsfrontend.controllers.SignInController.signInSsoSCP(continue_url: Option[RedirectUrl], origin: Option[String], accountType: Option[String])

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -140,18 +140,12 @@ google-analytics {
   host = auto
 }
 
-contact-frontend-host = "http://localhost:9250/contact/problem_reports_"
-
-reportAProblemPartialUrl = ${contact-frontend-host}"ajax?service="${appName}
-reportAProblemNonJSUrl = ${contact-frontend-host}"nonjs?service="${appName}
-
 controllers {
   com.kenshoo.play.metrics.MetricsController = {
     needsAuth = false
     needsLogging = false
     needsAuditing = false
   }
-
   confidenceLevel = 50
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,19 +14,9 @@
 
 include "frontend.conf"
 
-# Provides an implementation of AuditConnector.
-# An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 
 # Custom error handler
 play.http.errorHandler = "ErrorHandler"

--- a/docs/stubbed-ui.md
+++ b/docs/stubbed-ui.md
@@ -1,0 +1,38 @@
+## Stubbed UIs
+
+### [BAS Gateway Frontend](https://github.com/hmrc/bas-gateway-frontend/blob/master/README.md)
+#### GET         /bas-gateway/sign-in
+Initiates the login journey, eventually creating an authenticated MDTP session
+#### GET         /bas-gateway/sso-sign-in
+Initiates the sso login flow for BAS through MDTP
+#### GET         /bas-gateway/sign-out-without-state
+#### GET         /bas-gateway/sign-out-with-state
+#### GET         /bas-gateway/register
+Sends the user to register a new SCP account
+
+### [Company Auth Frontend](https://github.com/hmrc/company-auth-frontend/blob/master/README.md)
+#### GET /gg/sign-in?continue=:continueUrl&accountType=:accountType&origin=:origin
+Shows login page.
+
+#### POST /gg/sign-in?continue=:continueUrl&accountType=:accountType&origin=:origin
+Submits user's credentials, creates session and redirects to the provided continue URL
+
+### [Identity Verification Frontend](https://github.com/hmrc/identity-verification-frontend/blob/master/README.md)
+#### GET /mdtp/uplift?origin=:origin&confidenceLevel=:confidenceLevel&completionURL=:completionURL&failureURL=:failureURL
+Shows an identity verification page for the [IV "uplift" journey](https://github.com/hmrc/identity-verification-frontend/blob/master/README.md#get-mdtpuplift), offering the choice of either a successful or unsuccessful IV journey outcome.
+
+#### POST /mdtp/uplift?origin=:origin&confidenceLevel=:confidenceLevel&completionURL=:completionURL&failureURL=:failureURL
+Submits the desired outcome of the identity verification "uplift" journey.
+If a successful outcome was chosen, this will increase the confidence level of the current user to the provided confidence level and redirect to the provided completion URL.
+If an unsuccessful outcome was chosen, this will just redirect to the provided failure URL.
+
+## Custom UI
+
+#### GET /agents-external-stubs/user
+Shows current user auth settings
+
+#### GET /agents-external-stubs/user/edit
+Displays form to edit current user auth settings
+
+#### POST /agents-external-stubs/user/edit
+Submits amended user auth settings

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,13 +3,13 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVer = "7.15.0"
+  private val bootstrapVer = "7.22.0"
 
   lazy val compile = Seq(
     ws,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % bootstrapVer,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "7.7.0-play-28",
-    "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "1.2.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "7.23.0-play-28",
+    "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "1.14.0",
     "uk.gov.hmrc"       %% "play-partials"              % "8.4.0-play-28",
     "uk.gov.hmrc"       %% "agent-kenshoo-monitoring"   % "5.3.0",
     "com.typesafe.play" %% "play-json-joda"             % "2.9.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.1")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.14.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.1")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.14.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")

--- a/test/uk/gov/hmrc/agentsexternalstubsfrontend/views/ViewsSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubsfrontend/views/ViewsSpec.scala
@@ -157,6 +157,7 @@ class ViewsSpec extends UnitSpec with GuiceOneAppPerSuite {
       val html = view.render(
         title = "My custom page title",
         backLinkHref = Some("My custom backlink"),
+        showSignOut = true,
         wide = false,
         sidebar = Some(Html("My custom sidebar links")),
         mainContent = Html("My custom main content HTML"),
@@ -173,6 +174,7 @@ class ViewsSpec extends UnitSpec with GuiceOneAppPerSuite {
       val html2 = view.f(
         "My custom page title",
         Some("My custom backlink"),
+        true,
         false,
         Some(Html("My custom sidebar links"))
       )(Html("My custom main content HTML"))(FakeRequest(), appMessages)


### PR DESCRIPTION
New page http://localhost:9099/agents-external-stubs/quick-start-hub

Aim
-
Acts as a primer with links take you to a given service _after_ signing in.

Pros
- You do not need to be signed in to be on this page, unlike say, the test users page... 
- can reduce the number of bookmarks 

Cons
- links will always require sign in even if logged in as existing user
- At the moment it is localhost only - the urls make use of the continueUrl param with bas-gateway, in future could be used in higher environments but don't want to link to all our services via config if possible

From patch version agents-external-stubs-frontend 0.186.4 (have neatened the styles a bit more)
<img width="1039" alt="Screenshot 2023-10-24 at 16 39 38" src="https://github.com/hmrc/agents-external-stubs-frontend/assets/62263396/d1e70039-7368-4802-b93e-b3779437a8e0">
